### PR TITLE
refactor: centralize GameState type and clean up imports

### DIFF
--- a/src/config/pusherConfig.ts
+++ b/src/config/pusherConfig.ts
@@ -1,4 +1,3 @@
-// Configuração do Pusher
 export const pusherConfig = {
   appId: process.env.PUSHER_APP_ID || '',
   key: process.env.NEXT_PUBLIC_PUSHER_KEY || '',
@@ -7,7 +6,6 @@ export const pusherConfig = {
   useTLS: true
 };
 
-// Nome do canal e eventos do Pusher
 export const GAME_CHANNEL = 'game-channel';
 export const GAME_EVENTS = {
   ROOM_UPDATE: 'room-update',

--- a/src/hooks/useGameController.ts
+++ b/src/hooks/useGameController.ts
@@ -1,8 +1,9 @@
 "use client"
 
 import { useState, useEffect } from 'react';
-import { getInitialGameState, makeMove, GameState } from '@/utils/gameLogic';
+import { getInitialGameState, makeMove } from '@/utils/gameLogic';
 import { pusherService } from '@/services/pusherService';
+import { GameState } from '@/types/gameStateTypes';
 
 export const useGameController = () => {
   const [gameState, setGameState] = useState<GameState>(getInitialGameState({ 

--- a/src/hooks/useGameLogic.ts
+++ b/src/hooks/useGameLogic.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { GameState } from '../utils/gameLogic';
+import { GameState } from '@/types/gameStateTypes';
 
 export const useGameLogic = () => {
   const checkWinner = useCallback((board: string[]): string | null => {

--- a/src/hooks/useScoreboardLogic.ts
+++ b/src/hooks/useScoreboardLogic.ts
@@ -1,4 +1,4 @@
-import { GameState } from '@/utils/gameLogic';
+import { GameState } from "@/types/gameStateTypes";
 
 export const useScoreboardLogic = (gameState: GameState) => {
   const calculateWins = () => {

--- a/src/services/pusherService.ts
+++ b/src/services/pusherService.ts
@@ -1,27 +1,6 @@
 import Pusher from 'pusher-js';
 import { pusherConfig, GAME_CHANNEL, GAME_EVENTS } from '@/config/pusherConfig';
-
-interface RoomUpdate {
-  type: 'CREATE' | 'JOIN' | 'LEAVE' | 'UPDATE_STATUS' | 'GAME_MOVE';
-  room?: {
-    id: string;
-    name: string;
-    playerX: string | null;
-    playerO: string | null;
-    status: 'waiting' | 'playing' | 'finished';
-  };
-  gameState?: {
-    board: string[];
-    currentPlayer: string;
-    playerXName: string;
-    playerOName: string;
-    playerXScore: number;
-    playerOScore: number;
-    winner: string | null;
-    history: { player: string; position: number; winner: string | null }[];
-  };
-}
-
+import { RoomUpdate } from '@/types/roomTypes';
 class PusherService {
   private pusher: Pusher;
   private channel: import('pusher-js').Channel;

--- a/src/types/boardTypes.ts
+++ b/src/types/boardTypes.ts
@@ -1,4 +1,4 @@
-import { GameState } from "@/utils/gameLogic";
+import { GameState } from "./gameStateTypes";
 
 export interface BoardProps {
   gameState: GameState;

--- a/src/types/gameStatusTypes.ts
+++ b/src/types/gameStatusTypes.ts
@@ -1,4 +1,4 @@
-import { GameState } from '@/utils/gameLogic';
+import { GameState } from "./gameStateTypes";
 
 export interface GameStatusProps {
   gameState: GameState;

--- a/src/types/roomTypes.ts
+++ b/src/types/roomTypes.ts
@@ -5,3 +5,24 @@ export interface RoomProps {
   playerO: string | null;
   status: 'waiting' | 'playing' | 'finished';
 }
+
+export interface RoomUpdate {
+  type: 'CREATE' | 'JOIN' | 'LEAVE' | 'UPDATE_STATUS' | 'GAME_MOVE';
+  room?: {
+    id: string;
+    name: string;
+    playerX: string | null;
+    playerO: string | null;
+    status: 'waiting' | 'playing' | 'finished';
+  };
+  gameState?: {
+    board: string[];
+    currentPlayer: string;
+    playerXName: string;
+    playerOName: string;
+    playerXScore: number;
+    playerOScore: number;
+    winner: string | null;
+    history: { player: string; position: number; winner: string | null }[];
+  };
+}

--- a/src/types/scoreboardTypes.ts
+++ b/src/types/scoreboardTypes.ts
@@ -1,4 +1,4 @@
-import { GameState } from '@/utils/gameLogic';
+import { GameState } from "./gameStateTypes";
 
 export interface ScoreboardProps {
   gameState: GameState;

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -1,18 +1,9 @@
 import { GAME_CONFIG } from '@/config/gameConfig';
-
-export type GameState = {
-  board: string[];
-  currentPlayer: string;
-  playerXName: string;
-  playerOName: string;
-  playerXScore: number;
-  playerOScore: number;
-  winner: string | null;
-  history: { player: string; position: number; winner: string | null }[];
-};
+import { GameState } from '@/types/gameStateTypes';
 
 export const getInitialGameState = (currentState: GameState): GameState => {
   const randomPlayer = Math.random() < 0.5 ? GAME_CONFIG.PLAYERS.X.SYMBOL : GAME_CONFIG.PLAYERS.O.SYMBOL;
+  
   return {
     board: Array(GAME_CONFIG.BOARD_SIZE).fill(''),
     currentPlayer: randomPlayer,
@@ -26,7 +17,6 @@ export const getInitialGameState = (currentState: GameState): GameState => {
 };
 
 export const checkWinner = (board: string[]): string | null => {
-
   for (const combination of GAME_CONFIG.WINNING_COMBINATIONS) {
     const [a, b, c] = combination;
     if (board[a] && board[a] === board[b] && board[a] === board[c]) {


### PR DESCRIPTION
Move GameState type to a dedicated file (gameStateTypes.ts) to avoid duplication and improve maintainability. Remove unnecessary comments and clean up import paths across multiple files.